### PR TITLE
Support grapheme clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/gdamore/tcell/v2 v2.3.11
 	github.com/mattn/go-runewidth v0.0.10
+	github.com/rivo/uniseg v0.1.0
 	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf
 	golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6
 	gopkg.in/yaml.v2 v2.3.0

--- a/ui/draw_utils.go
+++ b/ui/draw_utils.go
@@ -5,18 +5,24 @@ import (
 	"time"
 
 	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/uniseg"
 )
 
 func printString(screen tcell.Screen, x *int, y int, s StyledString) {
 	style := tcell.StyleDefault
 	nextStyles := s.styles
-	for i, r := range s.string {
+	g := uniseg.NewGraphemes(s.string)
+	for i := 0; g.Next(); i += clusterSize(g) {
 		if 0 < len(nextStyles) && nextStyles[0].Start == i {
 			style = nextStyles[0].Style
 			nextStyles = nextStyles[1:]
 		}
-		screen.SetContent(*x, y, r, nil, style)
-		*x += runeWidth(r)
+		cluster := g.Runes()
+		if len(cluster) == 0 {
+			continue
+		}
+		screen.SetContent(*x, y, cluster[0], cluster[1:], style)
+		*x += stringWidth(g.Str())
 	}
 }
 

--- a/ui/style.go
+++ b/ui/style.go
@@ -10,20 +10,45 @@ import (
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/mattn/go-runewidth"
+	"github.com/rivo/uniseg"
 )
 
-var condition = runewidth.Condition{}
-
-func runeWidth(r rune) int {
-	return condition.RuneWidth(r)
+func clusterWidth(cluster []rune) int {
+	width := 0
+	for _, r := range cluster {
+		width += runewidth.RuneWidth(r)
+	}
+	return width
 }
 
 func stringWidth(s string) int {
-	return condition.StringWidth(s)
+	width := 0
+	for _, r := range s {
+		width += runewidth.RuneWidth(r)
+	}
+	return width
 }
 
 func truncate(s string, w int, tail string) string {
-	return condition.Truncate(s, w, tail)
+	width := stringWidth(s)
+	if width <= w {
+		return s
+	}
+	w -= stringWidth(tail)
+	end := len(s)
+	for i, r := range s {
+		if w < 0 {
+			end = i
+			break
+		}
+		w -= runewidth.RuneWidth(r)
+	}
+	return s[:end] + tail
+}
+
+func clusterSize(g *uniseg.Graphemes) int {
+	start, end := g.Positions()
+	return end - start
 }
 
 // Taken from <https://modern.ircdocs.horse/formatting.html>


### PR DESCRIPTION
## TODO

- [ ] make the input field work correctly
- [x] ~~figure out problems with foot:~~ explanation here https://codeberg.org/dnkl/foot/issues/782#issuecomment-278311
    1. the emoji seems to hide the text: ![screen-20211106233630](https://user-images.githubusercontent.com/51088794/140626678-725ee43e-b826-4d61-aa10-4314aa869606.png)
    2. selecting hidden letters uncovers them ![screen-20211106233722](https://user-images.githubusercontent.com/51088794/140626700-24c2511c-a961-4be4-8eee-d1706c760336.png)
    3. and you can unselect the thing and it (looks like it) works ![screen-20211106233802](https://user-images.githubusercontent.com/51088794/140626715-4e3528ee-bd87-4fb2-a2b9-08f1a08108b3.png)
- [ ] figure out problems with kitty: ![screen-20211106234039](https://user-images.githubusercontent.com/51088794/140626724-b073ad62-77e0-45c5-b9ac-37b5bb1e325f.png)
- [ ] figure out if some of the problems come from tcell

Related, maybe? 
- https://github.com/kovidgoyal/kitty/issues/4200
- https://codeberg.org/dnkl/foot/issues/782

It seems there is no way to compute the width of a grapheme cluster, so I think the best way to go is to not change the way senpai computes the width of strings (rune by rune), but still tell tcell to render the grapheme cluster as one.

***

senpai now correctly computes the width of unicode strings, such as
sequences of emoji interleaved with Zero-Width-Joiners, and the editor
goes from cluster to cluster, instead of codepoint (rune) to codepoint.

This breaks users on terminal that do not support grapheme clusters,
such as alacritty[0].

See http://unicode.org/reports/tr29/
and https://github.com/rivo/uniseg

[0] https://github.com/alacritty/alacritty/issues/3975